### PR TITLE
Make the build reproducible

### DIFF
--- a/src/cm_tophits.c
+++ b/src/cm_tophits.c
@@ -2780,8 +2780,10 @@ cm_tophits_TabularTail(FILE *ofp, const char *progname, enum cm_pipemodes_e pipe
   fprintf(ofp, "# Query file:      %s\n",      (qfile    == NULL) ? "[none]" : qfile);
   fprintf(ofp, "# Target file:     %s\n",      (tfile    == NULL) ? "[none]" : tfile);
   fprintf(ofp, "# Option settings: %s\n",      spoof_cmd);
-  fprintf(ofp, "# Current dir:     %s\n",      (cwd      == NULL) ? "[unknown]" : cwd);
-  fprintf(ofp, "# Date:            %s",        timestamp); /* timestamp ends in \n */
+  if (getenv("SOURCE_DATE_EPOCH") != NULL) {
+    fprintf(ofp, "# Current dir:     %s\n",      (cwd      == NULL) ? "[unknown]" : cwd);
+    fprintf(ofp, "# Date:            %s",        timestamp); /* timestamp ends in \n */
+  }
   fprintf(ofp, "# [ok]\n");
 
   free(spoof_cmd);


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) we noticed that infernal could not be built reproducibly.

This is because it embeds the current build timestamp and the absolute build directory from which it was built into generated files. This patch checks that if [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) is set and, if so, omits these fields.

(This was originally filed in Debian as [#946315](https://bugs.debian.org/946315))